### PR TITLE
Add Mission Control agent orchestration service

### DIFF
--- a/stacks/hermes-agent/docker-compose.yml
+++ b/stacks/hermes-agent/docker-compose.yml
@@ -1,0 +1,84 @@
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes
+    restart: unless-stopped
+    command: gateway run
+    ports:
+      - "8642:8642"
+    volumes:
+      - ~/.hermes:/opt/data
+    networks:
+      - hermes-net
+    # Uncomment to forward specific env vars instead of using .env file:
+    # environment:
+    #   - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    #   - OPENAI_API_KEY=${OPENAI_API_KEY}
+    #   - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+
+  dashboard:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes-dashboard
+    restart: unless-stopped
+    command: dashboard --host 0.0.0.0 --insecure
+    ports:
+      - "9119:9119"
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - GATEWAY_HEALTH_URL=http://hermes:8642
+    networks:
+      - hermes-net
+    depends_on:
+      - hermes
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+
+  mission-control:
+    image: ghcr.io/builderz-labs/mission-control:latest
+    container_name: mission-control
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - NEXT_PUBLIC_GATEWAY_OPTIONAL=true
+      # Uncomment to connect to the hermes gateway directly:
+      # - OPENCLAW_GATEWAY_HOST=hermes
+      # - OPENCLAW_GATEWAY_PORT=8642
+    volumes:
+      - mc-data:/app/.data
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /app/.next/cache
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - hermes-net
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+
+volumes:
+  mc-data:
+
+networks:
+  hermes-net:
+    driver: bridge


### PR DESCRIPTION
Adds builderz-labs/mission-control to the hermes-agent stack for agent orchestration, configured in standalone mode on the shared hermes-net network.