### PR TITLE
Add Glances monitoring service and infrastructure configuration

### DIFF
--- a/stacks/glances/docker-compose.yml
+++ b/stacks/glances/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  monitoring:
+    image: nicolargo/glances:latest-full
+    pid: host
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock
+    environment:
+      - "GLANCES_OPT=-w"

--- a/stacks/glances/infra.yml
+++ b/stacks/glances/infra.yml
@@ -1,0 +1,5 @@
+host: artemis
+deploy_path: /opt/stacks/infisical
+env_file: false
+docker_volumes: {}
+depends_on_stacks: []


### PR DESCRIPTION
Introduced a new Docker Compose file for the Glances monitoring service, utilizing the latest full image and configuring it to run with host networking. Additionally, created an infrastructure YAML file specifying the deployment host and path, with no environment file or Docker volumes defined.