### PR TITLE
Add new symbols and names for stocks in home.yml configuration

### DIFF
--- a/stacks/glance/config/home.yml
+++ b/stacks/glance/config/home.yml
@@ -68,6 +68,8 @@
               name: Cloudflare
             - symbol: AMD
               name: AMD
+            - symbol: PLTR
+              name: Palantir
 
         - type: releases
           cache: 1d
@@ -82,3 +84,4 @@
             - radarr/radarr
             - mealie-recipes/mealie
             - plexinc/pms-docker
+            - nous-research/hermes-agent


### PR DESCRIPTION
- Added Palantir (PLTR) to the stock list.
- Included nous-research/hermes-agent in the releases section.