### PR TITLE
Migrate deploy paths from /opt/stacks to /home/deploy/dockerlab

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -3,4 +3,4 @@ gateway_dir: "{{ playbook_dir }}/../../gateway"
 
 docker_compose_cmd: docker compose
 
-default_deploy_base: /opt/stacks
+default_deploy_base: /home/deploy/dockerlab/stacks

--- a/ansible/playbooks/setup-host.yml
+++ b/ansible/playbooks/setup-host.yml
@@ -67,11 +67,11 @@
         create_home: true
       when: ansible_user != 'deploy'
 
-    - name: Ensure /opt/stacks base directory exists
+    - name: Ensure deploy base directory exists
       ansible.builtin.file:
-        path: /opt/stacks
+        path: /home/deploy/dockerlab/stacks
         state: directory
-        owner: root
+        owner: deploy
         group: docker
         mode: "0750"
 

--- a/notes/dagu-orchestrator.md
+++ b/notes/dagu-orchestrator.md
@@ -151,7 +151,7 @@ block the others.
 | `./dags` → `/var/lib/dagu/dags` (ro) | DAG definitions from the repo |
 | `docker.sock` | Backup jobs exec into Postgres containers |
 | `~/.ssh` (ro) | Ansible SSH access to VPS hosts |
-| `/opt/dockerlab` (ro) | Repo checkout for deploy pipeline |
+| `/home/deploy/dockerlab` | Repo checkout for deploy pipeline |
 | `dagu-data` volume | Run history, logs, scheduler state |
 
 ### GitHub webhook

--- a/stacks/dagu/dags/deploy-stacks.yaml
+++ b/stacks/dagu/dags/deploy-stacks.yaml
@@ -4,7 +4,7 @@ type: graph
 params:
   - STACKS: ""
 
-working_dir: /opt/dockerlab
+working_dir: /home/deploy/dockerlab
 #dotenv: false
 
 steps:

--- a/stacks/dagu/docker-compose.yml
+++ b/stacks/dagu/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./dags:/var/lib/dagu/dags:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.ssh:/root/.ssh:ro
-      - /home/deploy/dockerlab:/opt/dockerlab
+      - /home/deploy/dockerlab:/home/deploy/dockerlab
     networks:
       - pangolin
     labels:

--- a/stacks/dagu/infra.yml
+++ b/stacks/dagu/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/dagu
+deploy_path: /home/deploy/dockerlab/stacks/dagu
 env_file: true
 secrets:
   - DOMAIN

--- a/stacks/glance/infra.yml
+++ b/stacks/glance/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/glance
+deploy_path: /home/deploy/dockerlab/stacks/glance
 env_file: true
 secrets:
   - DOMAIN

--- a/stacks/glances/infra.yml
+++ b/stacks/glances/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/infisical
+deploy_path: /home/deploy/dockerlab/stacks/glances
 env_file: false
 docker_volumes: {}
 depends_on_stacks: []

--- a/stacks/hermes-agent/infra.yml
+++ b/stacks/hermes-agent/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/hermes-agent
+deploy_path: /home/deploy/dockerlab/stacks/hermes-agent
 env_file: false
 docker_volumes: {}
 secrets:

--- a/stacks/infisical/infra.yml
+++ b/stacks/infisical/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/infisical
+deploy_path: /home/deploy/dockerlab/stacks/infisical
 env_file: true
 secrets:
   - DOMAIN

--- a/stacks/jenkins/infra.yml
+++ b/stacks/jenkins/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/jenkins
+deploy_path: /home/deploy/dockerlab/stacks/jenkins
 env_file: true
 secrets:
   - DOMAIN

--- a/stacks/mealie/infra.yml
+++ b/stacks/mealie/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/mealie
+deploy_path: /home/deploy/dockerlab/stacks/mealie
 env_file: true
 secrets:
   - DOMAIN

--- a/stacks/uptime/infra.yml
+++ b/stacks/uptime/infra.yml
@@ -1,5 +1,5 @@
 host: artemis
-deploy_path: /opt/stacks/uptime
+deploy_path: /home/deploy/dockerlab/stacks/uptime
 env_file: true
 secrets:
   - DOMAIN


### PR DESCRIPTION
Updates default_deploy_base, all infra.yml deploy_path values, setup-host playbook directory creation, Dagu compose volume mount, and deploy DAG working_dir. Also fixes glances infra.yml which was incorrectly pointing to /opt/stacks/infisical.