### PR TITLE
Add email and OpenAI settings to Mealie docker-compose.yml

### DIFF
--- a/stacks/mealie/docker-compose.yml
+++ b/stacks/mealie/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       POSTGRES_SERVER: mealie-db
       POSTGRES_PORT: 5432
       POSTGRES_DB: mealie
+      # Email Settings
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}
@@ -37,6 +38,7 @@ services:
       SMTP_AUTH_STRATEGY: 'NONE'
       SMTP_FROM_NAME: Mealie
       SMTP_FROM_EMAIL: cookbook@${DOMAIN}
+      # OpenAI Settings
       OPENAI_BASE_URL: ${OPENAI_BASE_URL}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_MODEL: zai-org/GLM-5.1


### PR DESCRIPTION
- Introduced comments for email and OpenAI settings to enhance clarity in the configuration.
- Ensured environment variables for SMTP and OpenAI are clearly defined for better understanding.

These updates improve the documentation within the docker-compose file, aiding future configuration management.