### PR TITLE
Add Vikunja task manager stack

### DIFF
--- a/stacks/vikunja/docker-compose.yml
+++ b/stacks/vikunja/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: vikunja/vikunja
     container_name: vikunja
     restart: unless-stopped
+    ports:
+      - "3456:3456"
     networks:
       - vikunja
       - pangolin

--- a/stacks/vikunja/docker-compose.yml
+++ b/stacks/vikunja/docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  vikunja:
+    image: vikunja/vikunja
+    container_name: vikunja
+    restart: unless-stopped
+    networks:
+      - vikunja
+      - pangolin
+    environment:
+      VIKUNJA_SERVICE_PUBLICURL: https://vikunja.${DOMAIN}
+      VIKUNJA_DATABASE_HOST: vikunja-db
+      VIKUNJA_DATABASE_PASSWORD: ${VIKUNJA_DB_PASSWORD}
+      VIKUNJA_DATABASE_TYPE: postgres
+      VIKUNJA_DATABASE_USER: vikunja
+      VIKUNJA_DATABASE_DATABASE: vikunja
+      VIKUNJA_SERVICE_SECRET: ${VIKUNJA_SERVICE_SECRET}
+      VIKUNJA_SERVICE_ENABLEREGISTRATION: false
+    volumes:
+      - vikunja-files:/app/vikunja/files
+    depends_on:
+      vikunja-db:
+        condition: service_healthy
+    #labels:
+      # Pangolin blueprint (public resource) — see https://docs.pangolin.net/manage/blueprints
+      # - pangolin.public-resources.vikunja.name=vikunja
+      # - pangolin.public-resources.vikunja.full-domain=vikunja.${DOMAIN}
+      # - pangolin.public-resources.vikunja.protocol=http
+      # - pangolin.public-resources.vikunja.targets[0].hostname=vikunja
+      # - pangolin.public-resources.vikunja.targets[0].port=3456
+      # - pangolin.public-resources.vikunja.targets[0].path=/
+      # - pangolin.public-resources.vikunja.targets[0].method=http
+
+  vikunja-db:
+    image: postgres:18
+    container_name: vikunja-db
+    restart: unless-stopped
+    networks:
+      - vikunja
+    environment:
+      POSTGRES_PASSWORD: ${VIKUNJA_DB_PASSWORD}
+      POSTGRES_USER: vikunja
+      POSTGRES_DB: vikunja
+    volumes:
+      - vikunja-pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -U vikunja"]
+      interval: 2s
+      start_period: 30s
+
+volumes:
+  vikunja-files:
+    external: true
+  vikunja-pgdata:
+    external: true
+
+networks:
+  pangolin:
+    external: true
+  vikunja:
+    driver: bridge

--- a/stacks/vikunja/infra.yml
+++ b/stacks/vikunja/infra.yml
@@ -1,0 +1,13 @@
+host: artemis
+deploy_path: /home/deploy/dockerlab/stacks/vikunja
+env_file: true
+secrets:
+  - DOMAIN
+  - VIKUNJA_DB_PASSWORD
+  - VIKUNJA_SERVICE_SECRET
+docker_volumes:
+  vikunja-files:
+    backup: true
+  vikunja-pgdata:
+    backup: true
+depends_on_stacks: []


### PR DESCRIPTION
## Summary
- Add a new `stacks/vikunja` deployment with Vikunja and Postgres 18, based on the [official Docker Compose example](https://vikunja.io/docs/full-docker-example)
- Wire the service into the Pangolin network with public resource labels for `vikunja.${DOMAIN}` (currently commented out pending gateway setup)
- Add `infra.yml` with deploy path, required secrets, and backup-enabled volumes

## Test plan
- [ ] Add `VIKUNJA_DB_PASSWORD` and `VIKUNJA_SERVICE_SECRET` to secrets store
- [ ] Create external volumes `vikunja-files` and `vikunja-pgdata` on artemis
- [ ] Deploy stack and verify Vikunja starts and connects to Postgres
- [ ] Uncomment Pangolin labels and confirm `https://vikunja.${DOMAIN}` is reachable
- [ ] Register first user (registration is disabled by default)


Made with [Cursor](https://cursor.com)