### PR TITLE
Add Dockerfile and update docker-compose.yml for hermes-agent service

### DIFF
--- a/ansible/playbooks/deploy-gateway.yml
+++ b/ansible/playbooks/deploy-gateway.yml
@@ -25,6 +25,7 @@
         argv:
           - rsync
           - -az
+          - --itemize-changes
           - --delete
           - --exclude=config/config.yml
           - --exclude=config/letsencrypt
@@ -35,6 +36,7 @@
           - "{{ ansible_user }}@{{ ansible_host }}:{{ gateway_deploy_path }}/"
       delegate_to: localhost
       register: sync_result
+      changed_when: sync_result.stdout | length > 0
 
     - name: Render gateway .env
       ansible.builtin.copy:

--- a/ansible/roles/docker_stack/tasks/main.yml
+++ b/ansible/roles/docker_stack/tasks/main.yml
@@ -19,6 +19,7 @@
     argv:
       - rsync
       - -az
+      - --itemize-changes
       - --delete
       - --exclude=infra.yml
       - -e
@@ -27,6 +28,7 @@
       - "{{ ansible_user }}@{{ ansible_host }}:{{ docker_stack_deploy_path }}/"
   delegate_to: localhost
   register: docker_stack_sync_result
+  changed_when: docker_stack_sync_result.stdout | length > 0
 
 - name: Render .env from secrets — {{ docker_stack_name }}
   ansible.builtin.template:
@@ -47,7 +49,10 @@
     chdir: "{{ docker_stack_deploy_path }}"
   when: docker_stack_dockerfile.stat.exists
   register: docker_stack_build_result
-  changed_when: "'Successfully built' in docker_stack_build_result.stderr or 'exporting to image' in docker_stack_build_result.stderr or 'Built' in docker_stack_build_result.stderr"
+  changed_when: >
+    'Successfully built' in docker_stack_build_result.stderr
+    or 'exporting to image' in docker_stack_build_result.stderr
+    or 'Built' in docker_stack_build_result.stderr
 
 - name: Pull images — {{ docker_stack_name }}
   ansible.builtin.command:

--- a/ansible/roles/docker_stack/tasks/main.yml
+++ b/ansible/roles/docker_stack/tasks/main.yml
@@ -36,9 +36,22 @@
   when: stack_infra.env_file | default(false)
   register: docker_stack_env_result
 
+- name: Check for Dockerfile — {{ docker_stack_name }}
+  ansible.builtin.stat:
+    path: "{{ docker_stack_deploy_path }}/Dockerfile"
+  register: docker_stack_dockerfile
+
+- name: Build images — {{ docker_stack_name }}
+  ansible.builtin.command:
+    cmd: "{{ docker_compose_cmd }} build"
+    chdir: "{{ docker_stack_deploy_path }}"
+  when: docker_stack_dockerfile.stat.exists
+  register: docker_stack_build_result
+  changed_when: "'Successfully built' in docker_stack_build_result.stderr or 'exporting to image' in docker_stack_build_result.stderr or 'Built' in docker_stack_build_result.stderr"
+
 - name: Pull images — {{ docker_stack_name }}
   ansible.builtin.command:
-    cmd: "{{ docker_compose_cmd }} pull"
+    cmd: "{{ docker_compose_cmd }} pull{{ ' --ignore-buildable' if docker_stack_dockerfile.stat.exists else '' }}"
     chdir: "{{ docker_stack_deploy_path }}"
   register: docker_stack_pull_result
   changed_when: "'Pull complete' in docker_stack_pull_result.stdout or 'Downloaded' in docker_stack_pull_result.stdout"

--- a/stacks/hermes-agent/Dockerfile
+++ b/stacks/hermes-agent/Dockerfile
@@ -1,0 +1,10 @@
+FROM nousresearch/hermes-agent:latest
+
+USER root
+
+ENV OPENCODE_DISABLE_AUTOUPDATE=true
+
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path \
+    && install -m 755 /root/.opencode/bin/opencode /usr/local/bin/opencode \
+    && rm -rf /root/.opencode \
+    && opencode --version

--- a/stacks/hermes-agent/docker-compose.yml
+++ b/stacks/hermes-agent/docker-compose.yml
@@ -1,6 +1,12 @@
+x-hermes-image: &hermes-image
+  build:
+    context: .
+    dockerfile: Dockerfile
+  image: hermes-agent-opencode:latest
+
 services:
   hermes:
-    image: nousresearch/hermes-agent:latest
+    <<: *hermes-image
     container_name: hermes
     restart: unless-stopped
     command: gateway run
@@ -22,7 +28,7 @@ services:
           cpus: "2.0"
 
   dashboard:
-    image: nousresearch/hermes-agent:latest
+    <<: *hermes-image
     container_name: hermes-dashboard
     restart: unless-stopped
     command: dashboard --host 0.0.0.0 --insecure


### PR DESCRIPTION
- Introduced a new Dockerfile for the hermes-agent service to customize the image build process.
- Updated docker-compose.yml to use the new hermes-image configuration for both hermes and dashboard services, ensuring consistent image usage and build context.
- Enhanced the pull command to conditionally ignore buildable images based on the presence of the Dockerfile.