### PR TITLE
[HL-4] Add Grocy stack to dockerlab

### DIFF
--- a/stacks/grocy/docker-compose.yml
+++ b/stacks/grocy/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  grocy:
+    image: lscr.io/linuxserver/grocy:4.6.0
+    container_name: grocy
+    restart: unless-stopped
+    networks:
+      - grocy
+      - pangolin
+    environment:
+      PUID: 1000
+      PGID: 1000
+      TZ: America/Los_Angeles
+    volumes:
+      - grocy-config:/config
+    labels:
+      # Pangolin blueprint (public resource) — see https://docs.pangolin.net/manage/blueprints
+      - pangolin.public-resources.grocy.name=grocy
+      - pangolin.public-resources.grocy.full-domain=grocy.${DOMAIN}
+      - pangolin.public-resources.grocy.protocol=http
+      - pangolin.public-resources.grocy.targets[0].hostname=grocy
+      - pangolin.public-resources.grocy.targets[0].port=80
+      - pangolin.public-resources.grocy.targets[0].path=/
+      - pangolin.public-resources.grocy.targets[0].method=http
+
+volumes:
+  grocy-config:
+    external: true
+
+networks:
+  pangolin:
+    external: true
+  grocy:
+    driver: bridge

--- a/stacks/grocy/infra.yml
+++ b/stacks/grocy/infra.yml
@@ -1,0 +1,9 @@
+host: artemis
+deploy_path: /home/deploy/dockerlab/stacks/grocy
+env_file: true
+secrets:
+  - DOMAIN
+docker_volumes:
+  grocy-config:
+    backup: true
+depends_on_stacks: []


### PR DESCRIPTION
## Summary
- Adds `stacks/grocy/docker-compose.yml` using LinuxServer Grocy 4.6.0 on artemis
- Exposes Grocy via Pangolin at `grocy.${DOMAIN}` for stable HTTPS + API access (replacing HA add-on ingress)
- Adds `stacks/grocy/infra.yml` with `grocy-config` volume backup enabled

Vikunja: **HL-4**

## Test plan
- [ ] Deploy stack to artemis via Dagu/Ansible pipeline
- [ ] Confirm Grocy UI loads at `https://grocy.<domain>`
- [ ] Set Grocy BASE_URL to match public URL
- [ ] Verify REST API with `GROCY-API-KEY` (`grocy_pipeline.py ping`)
- [ ] Migrate data from HA add-on if needed, then disable add-on


Made with [Cursor](https://cursor.com)