### PR TITLE
[HL-4] Disable unused Grocy modules

### DIFF
--- a/stacks/grocy/docker-compose.yml
+++ b/stacks/grocy/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       PUID: 1000
       PGID: 1000
       TZ: America/Los_Angeles
+      # Grocy settings via env — see https://github.com/grocy/grocy/blob/master/config-dist.php
+      GROCY_FEATURE_FLAG_RECIPES: ${GROCY_FEATURE_FLAG_RECIPES:-false}
+      GROCY_FEATURE_FLAG_RECIPES_MEALPLAN: ${GROCY_FEATURE_FLAG_RECIPES_MEALPLAN:-false}
+      GROCY_FEATURE_FLAG_BATTERIES: ${GROCY_FEATURE_FLAG_BATTERIES:-false}
     volumes:
       - grocy-config:/config
     labels:

--- a/stacks/grocy/docker-compose.yml
+++ b/stacks/grocy/docker-compose.yml
@@ -10,10 +10,9 @@ services:
       PUID: 1000
       PGID: 1000
       TZ: America/Los_Angeles
-      # Grocy settings via env — see https://github.com/grocy/grocy/blob/master/config-dist.php
-      GROCY_FEATURE_FLAG_RECIPES: ${GROCY_FEATURE_FLAG_RECIPES:-false}
-      GROCY_FEATURE_FLAG_RECIPES_MEALPLAN: ${GROCY_FEATURE_FLAG_RECIPES_MEALPLAN:-false}
-      GROCY_FEATURE_FLAG_BATTERIES: ${GROCY_FEATURE_FLAG_BATTERIES:-false}
+      GROCY_FEATURE_FLAG_RECIPES: false
+      GROCY_FEATURE_FLAG_RECIPES_MEALPLAN: false
+      GROCY_FEATURE_FLAG_BATTERIES: false
     volumes:
       - grocy-config:/config
     labels:


### PR DESCRIPTION
## Summary
- Disables recipes, meal plan, and batteries in the Grocy stack via hardcoded `GROCY_FEATURE_FLAG_*` settings
- Keeps stock and shopping list enabled for pantry/spice inventory use

Vikunja: **HL-4**

## Test plan
- [ ] Redeploy grocy stack on artemis
- [ ] Confirm recipes, meal plan, and batteries are hidden in the UI
- [ ] Confirm stock and shopping list still work


Made with [Cursor](https://cursor.com)