### PR TITLE
[HL-5] Pin hermes-agent to v2026.6.5

### DIFF
--- a/stacks/hermes-agent/Dockerfile
+++ b/stacks/hermes-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent:latest
+FROM nousresearch/hermes-agent:v2026.6.5
 
 USER root
 


### PR DESCRIPTION
## Summary
- Pins `stacks/hermes-agent/Dockerfile` base image from `latest` to `v2026.6.5` (Hermes Agent v0.16.0)
- Keeps the custom opencode layer; rebuild required on deploy

**Vikunja:** [HL-5](https://vikunja.christerrile.com/tasks/5) — Update hermes-agent stack to v2026.6.5

## Test plan
- [ ] Rebuild image: `docker compose build` in `stacks/hermes-agent`
- [ ] Redeploy stack and confirm gateway starts on port 8642
- [ ] Confirm dashboard reachable on port 9119