### PR TITLE
[HL-7] Update hermes-agent stack to latest Docker image

### DIFF
--- a/stacks/hermes-agent/Dockerfile
+++ b/stacks/hermes-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent:v2026.6.5
+FROM nousresearch/hermes-agent:v2026.6.19
 
 USER root
 


### PR DESCRIPTION
## Summary
- Bump `nousresearch/hermes-agent` base image in `stacks/hermes-agent/Dockerfile` from `v2026.6.5` to `v2026.6.19`
- Rebuild on deploy will refresh the custom opencode layer on top of the updated base image

**Vikunja:** [HL-7](https://vikunja.christerrile.com/tasks/7) — Update hermes-agent stack to latest Docker image

## Test plan
- [ ] Merge and trigger hermes-agent stack deploy
- [ ] Verify `hermes` gateway starts on port 8642
- [ ] Verify `hermes-dashboard` starts on port 9119
- [ ] Confirm opencode install step succeeds during image build


Made with [Cursor](https://cursor.com)