### PR TITLE
[HL-3] Trigger Dagu Git Sync pull for DAG definitions

### DIFF
--- a/stacks/dagu/dags/deploy-stacks.yaml
+++ b/stacks/dagu/dags/deploy-stacks.yaml
@@ -1,4 +1,4 @@
-description: Deploy Docker Compose stacks via Ansible
+description: Deploy Docker Compose stacks via Ansible (Git Sync managed)
 
 env:
   - INFISICAL_PROJECT_ID: ${INFISICAL_PROJECT_ID}


### PR DESCRIPTION
## Summary
- DAG-only change under `stacks/dagu/dags/` to trigger the `sync-dagu-dags` job on merge
- Calls `POST /api/v1/sync/pull` so Dagu loads workflow YAML without a full stack redeploy
- Follow-up to #32 where bootstrap-dagu failed and DAGs never synced

**Vikunja:** [HL-3](https://vikunja.christerrile.com/tasks/3) — Decouple Dagu workflow deployments from main deployment action

## Test plan
- [ ] Merge and confirm only `sync-dagu-dags` runs (not `bootstrap-dagu` or `deploy`)
- [ ] Verify `sync-dagu-dags` succeeds
- [ ] Confirm `deploy-stacks` and `backup-postgres` appear in the Dagu UI


Made with [Cursor](https://cursor.com)