### PR TITLE
[HL-3] Fix Git Sync pull blocked by read-only mode

### DIFF
--- a/notes/dagu-orchestrator.md
+++ b/notes/dagu-orchestrator.md
@@ -198,6 +198,10 @@ of redeploying the Dagu container.
 The `dagu` stack itself is excluded from routine `deploy-stacks` runs. Runtime
 changes (Dockerfile, compose, image) use a dedicated bootstrap path.
 
+On startup, `/etc/custom-init.d/01-data-perms.sh` ensures `/var/lib/dagu` (including
+`dags/`) is owned by `PUID`/`PGID`. Git Sync and the DAG index both need write
+access there after the bind mount was removed.
+
 Each deploy run clones a fresh copy of the repo into the `workspace` volume,
 so there are no ownership conflicts and no stale state from previous runs.
 

--- a/notes/dagu-orchestrator.md
+++ b/notes/dagu-orchestrator.md
@@ -251,8 +251,10 @@ POST https://ops.${DOMAIN}/api/v1/sync/pull
 Authorization: Bearer <DAGU_API_KEY>
 ```
 
-Requires `permissions.write_dags` on the API key. Triggered when only
-`stacks/dagu/dags/**` files change — no container redeploy needed.
+Requires `permissions.write_dags` on the API key and `DAGU_GITSYNC_PUSH_ENABLED=true`
+(Dagu treats pull as a local DAG write; `push_enabled: false` blocks sync entirely).
+Triggered when only `stacks/dagu/dags/**` files change — no container redeploy needed
+unless Git Sync env vars changed.
 
 ### Git Sync configuration
 
@@ -265,7 +267,7 @@ demand via the sync/pull endpoint:
 | `DAGU_GITSYNC_REPOSITORY` | `https://github.com/cterrile/dockerlab.git` |
 | `DAGU_GITSYNC_BRANCH` | `main` |
 | `DAGU_GITSYNC_PATH` | `stacks/dagu/dags` |
-| `DAGU_GITSYNC_PUSH_ENABLED` | `false` (read-only) |
+| `DAGU_GITSYNC_PUSH_ENABLED` | `true` (required for pull/sync; blocks publish from UI if RBAC restricts write) |
 | `DAGU_GITSYNC_AUTH_TOKEN` | GitHub token for private repo access |
 
 ### GitHub Actions secrets required
@@ -274,4 +276,4 @@ demand via the sync/pull endpoint:
 |--------|-------------|
 | `DAGU_WEBHOOK_URL` | Dagu base URL (e.g. `https://ops.example.com`) |
 | `DAGU_WEBHOOK_TOKEN` | Webhook bearer token (`dagu_wh_...`) for triggering |
-| `DAGU_API_KEY` | Dagu API key (view-only is sufficient) for status polling |
+| `DAGU_API_KEY` | Dagu API key with `write_dags` for Git Sync pull; view-only suffices for deploy polling |

--- a/stacks/dagu/Dockerfile
+++ b/stacks/dagu/Dockerfile
@@ -35,10 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /etc/custom-init.d /workspace \
     && printf '%s\n' \
         '#!/bin/sh' \
-        'mkdir -p /workspace' \
-        'chown -R "${PUID}:${PGID}" /workspace' \
-        > /etc/custom-init.d/01-workspace-perms.sh \
-    && chmod +x /etc/custom-init.d/01-workspace-perms.sh \
+        'mkdir -p /workspace "${DAGU_HOME:-/var/lib/dagu}/dags"' \
+        'chown -R "${PUID}:${PGID}" /workspace "${DAGU_HOME:-/var/lib/dagu}"' \
+        > /etc/custom-init.d/01-data-perms.sh \
+    && chmod +x /etc/custom-init.d/01-data-perms.sh \
     && ln -sf /opt/ansible/bin/ansible /usr/local/bin/ansible \
     && ln -sf /opt/ansible/bin/ansible-playbook /usr/local/bin/ansible-playbook \
     && ln -sf /opt/ansible/bin/ansible-galaxy /usr/local/bin/ansible-galaxy \

--- a/stacks/dagu/docker-compose.yml
+++ b/stacks/dagu/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - DAGU_GITSYNC_REPOSITORY=https://github.com/cterrile/dockerlab.git
       - DAGU_GITSYNC_BRANCH=main
       - DAGU_GITSYNC_PATH=stacks/dagu/dags
-      - DAGU_GITSYNC_PUSH_ENABLED=false
+      - DAGU_GITSYNC_PUSH_ENABLED=true
       - DAGU_GITSYNC_AUTOSYNC_ENABLED=true
       - DAGU_GITSYNC_AUTOSYNC_ON_STARTUP=true
       - DAGU_GITSYNC_AUTOSYNC_INTERVAL=300


### PR DESCRIPTION
## Summary
- Set `DAGU_GITSYNC_PUSH_ENABLED=true` in the Dagu compose file
- Dagu treats Git Sync **pull** as a local DAG write; `push_enabled: false` blocks pull, auto-sync on startup, and `POST /api/v1/sync/pull` (403)
- Update docs to reflect the requirement

**Vikunja:** [HL-3](https://vikunja.christerrile.com/tasks/3) — Decouple Dagu workflow deployments from main deployment action

## Test plan
- [ ] Merge triggers `bootstrap-dagu` (compose runtime change)
- [ ] If bootstrap fails (self-deploy), manually restart on artemis: `docker compose up -d` in `/home/deploy/dockerlab/stacks/dagu`
- [ ] Confirm DAGs appear in Dagu UI after restart (auto-sync on startup)
- [ ] Re-run or push a DAG-only change and confirm `sync-dagu-dags` succeeds


Made with [Cursor](https://cursor.com)