### PR TITLE
[HL-8] Test VPS deployment to icarus

### DIFF
--- a/ansible/inventory/host_vars/icarus.yml
+++ b/ansible/inventory/host_vars/icarus.yml
@@ -1,0 +1,2 @@
+---
+ansible_host: "{{ lookup('env', 'ICARUS_ANSIBLE_HOST') }}"

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -9,7 +9,7 @@ all:
     vps:
       hosts:
         icarus:
-          ansible_host: CHANGEME       # DigitalOcean droplet IP or hostname
+          # ansible_host from ICARUS_ANSIBLE_HOST (Infisical prod) — see host_vars/icarus.yml
           ansible_user: deploy
           ansible_ssh_private_key_file: /home/dagu/.ssh/id_ed25519
         # Add future VPS hosts here:

--- a/stacks/whoami/docker-compose.yml
+++ b/stacks/whoami/docker-compose.yml
@@ -3,5 +3,19 @@ services:
     image: traefik/whoami:latest
     container_name: whoami
     restart: unless-stopped
-    ports:
-      - "8080:80"
+    networks:
+      - pangolin
+    labels:
+      # Pangolin blueprint (public resource) — see https://docs.pangolin.net/manage/blueprints
+      - pangolin.public-resources.whoami.name=whoami
+      - pangolin.public-resources.whoami.full-domain=whoami.${DOMAIN}
+      - pangolin.public-resources.whoami.protocol=http
+      - pangolin.public-resources.whoami.targets[0].hostname=whoami
+      - pangolin.public-resources.whoami.targets[0].port=80
+      - pangolin.public-resources.whoami.targets[0].path=/
+      - pangolin.public-resources.whoami.targets[0].method=http
+
+networks:
+  pangolin:
+    external: true
+    name: pangolin

--- a/stacks/whoami/docker-compose.yml
+++ b/stacks/whoami/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  whoami:
+    image: traefik/whoami:latest
+    container_name: whoami
+    restart: unless-stopped
+    ports:
+      - "8080:80"

--- a/stacks/whoami/infra.yml
+++ b/stacks/whoami/infra.yml
@@ -1,0 +1,4 @@
+host: icarus
+deploy_path: /home/deploy/dockerlab/stacks/whoami
+env_file: false
+depends_on_stacks: []

--- a/stacks/whoami/infra.yml
+++ b/stacks/whoami/infra.yml
@@ -1,4 +1,6 @@
 host: icarus
 deploy_path: /home/deploy/dockerlab/stacks/whoami
-env_file: false
+env_file: true
+secrets:
+  - DOMAIN
 depends_on_stacks: []


### PR DESCRIPTION
## Summary
- Add minimal `whoami` stack targeting `icarus` for VPS deploy validation
- Resolve `icarus` `ansible_host` from Infisical via `host_vars/icarus.yml` (`ICARUS_ANSIBLE_HOST`)
- Remove `CHANGEME` placeholder from inventory

**Vikunja:** [HL-8](https://vikunja.christerrile.com/tasks/8) — Test VPS deployment to icarus with whoami stack

## Test plan
- [ ] Confirm `ICARUS_ANSIBLE_HOST` set in Infisical prod
- [ ] CI validate + ansible-lint pass
- [ ] Merge → deploy workflow triggers `whoami` stack with `--limit icarus`
- [ ] On icarus: `curl http://localhost:8080` returns whoami response
- [ ] Vikunja HL-8 auto-closes on successful deploy

Made with [Cursor](https://cursor.com)