### PR TITLE
[HL-8] Disable sudo for VPS stack deploys

### DIFF
--- a/ansible/inventory/group_vars/vps.yml
+++ b/ansible/inventory/group_vars/vps.yml
@@ -1,2 +1,3 @@
-ansible_become: true
-ansible_become_method: sudo
+# VPS hosts: deploy user owns stack paths and runs docker via group membership.
+# Bootstrap playbooks (setup-host.yml) set become: true explicitly when sudo is needed.
+ansible_become: false


### PR DESCRIPTION
## Summary
- Set `ansible_become: false` in VPS group vars so stack deploys run as `deploy` without sudo (matches home/artemis pattern)
- Bootstrap playbooks (`setup-host.yml`, `deploy-gateway.yml`) still declare `become: true` explicitly when needed

Fixes icarus deploy failure: `Missing sudo password` during Gather Facts.

**Vikunja:** [HL-8](https://vikunja.christerrile.com/tasks/8) — Test VPS deployment to icarus with whoami stack

## Test plan
- [ ] Merge → deploy workflow runs (ansible change triggers full deploy)
- [ ] whoami stack deploys to icarus without sudo error
- [ ] Confirm whoami reachable at `https://whoami.<domain>` once Pangolin/newt is set up on icarus

Made with [Cursor](https://cursor.com)