### PR TITLE
[HL-9] Improve Vikunja workflow scripts for PR review status

### DIFF
--- a/scripts/vikunja/finish-work.sh
+++ b/scripts/vikunja/finish-work.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Record worker completion when a PR is opened (does not mark the ticket done).
-# Sets end_date (if unset) and comments with the PR URL.
+# Sets end_date (if unset), moves to For Review, and comments with the PR URL.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,6 +23,7 @@ TASK_JSON=$(curl -sf \
   "${VIKUNJA_API_URL}/tasks/${TASK_ID}")
 
 IDENTIFIER=$(echo "$TASK_JSON" | jq -r '.identifier // empty')
+PROJECT_ID=$(echo "$TASK_JSON" | jq -r '.project_id')
 END_DATE=$(echo "$TASK_JSON" | jq -r '.end_date // empty')
 DONE=$(echo "$TASK_JSON" | jq -r '.done // false')
 
@@ -44,6 +45,8 @@ if vikunja_date_unset "$END_DATE"; then
 else
   echo "end_date already set on ${IDENTIFIER:-$TASK_ID} — leaving unchanged"
 fi
+
+vikunja_move_task_to_bucket "$TASK_ID" "$PROJECT_ID" "for_review" "${IDENTIFIER:-$TASK_ID}"
 
 vikunja_add_comment "$TASK_ID" "PR opened: ${PR_URL}"
 echo "Commented on ${IDENTIFIER:-$TASK_ID} with PR link"

--- a/scripts/vikunja/lib.sh
+++ b/scripts/vikunja/lib.sh
@@ -27,3 +27,134 @@ vikunja_add_comment() {
 vikunja_date_unset() {
   [[ "${1:-}" == "0001-01-01"* || -z "${1:-}" ]]
 }
+
+vikunja_kanban_view_for_project() {
+  case "$1" in
+    3) echo 12 ;; # HL
+    1) echo 4 ;;  # ME
+    *) echo "" ;;
+  esac
+}
+
+vikunja_bucket_fallback_id() {
+  local project_id="$1"
+  local bucket_kind="$2"
+  case "${project_id}:${bucket_kind}" in
+    3:doing) echo 8 ;;
+    3:for_review) echo 13 ;;
+    1:doing) echo 2 ;;
+    # ME For Review: add column in Vikunja, probe bucket id, then set 1:for_review)
+    *) echo "" ;;
+  esac
+}
+
+vikunja_buckets_list_failed() {
+  local buckets_json="$1"
+  echo "$buckets_json" | jq -e 'type == "object" and (.message != null or .code != null)' >/dev/null 2>&1
+}
+
+vikunja_find_bucket_id() {
+  local buckets_json="$1"
+  local bucket_kind="$2"
+  local project_id="$3"
+  local jq_filter
+  local bucket_id
+
+  case "$bucket_kind" in
+    doing)
+      jq_filter='[.[] | select(
+        (.title | ascii_downcase) == "doing"
+        or (.title | ascii_downcase) == "in progress"
+        or (.title | ascii_downcase | test("in[ -]?progress"))
+        or (.title | ascii_downcase | test("^doing"))
+      )] | first | .id // empty'
+      ;;
+    for_review)
+      jq_filter='[.[] | select(
+        (.title | ascii_downcase) == "for review"
+        or (.title | ascii_downcase | test("for[ -]?review"))
+        or (.title | ascii_downcase) == "review"
+        or (.title | ascii_downcase | test("^in[ -]?review"))
+      )] | first | .id // empty'
+      ;;
+    *)
+      echo "::warning::Unknown bucket kind ${bucket_kind}" >&2
+      return 1
+      ;;
+  esac
+
+  bucket_id=$(echo "$buckets_json" | jq -r "
+    if type == \"object\" and .message then empty else
+      ${jq_filter}
+    end
+  ")
+
+  if { [ -z "$bucket_id" ] || [ "$bucket_id" = "null" ]; } \
+    && vikunja_buckets_list_failed "$buckets_json"; then
+    bucket_id="$(vikunja_bucket_fallback_id "$project_id" "$bucket_kind")"
+    if [ -n "$bucket_id" ]; then
+      echo "Buckets list unavailable — using fallback ${bucket_kind} bucket id ${bucket_id} for project ${project_id}" >&2
+    fi
+  fi
+
+  if [ -z "$bucket_id" ] || [ "$bucket_id" = "null" ]; then
+    bucket_id="$(vikunja_bucket_fallback_id "$project_id" "$bucket_kind")"
+    if [ -n "$bucket_id" ]; then
+      echo "Using fallback ${bucket_kind} bucket id ${bucket_id} for project ${project_id}" >&2
+    fi
+  fi
+
+  if [ -z "$bucket_id" ] || [ "$bucket_id" = "null" ]; then
+    return 1
+  fi
+
+  echo "$bucket_id"
+}
+
+vikunja_move_task_to_bucket() {
+  local task_id="$1"
+  local project_id="$2"
+  local bucket_kind="$3"
+  local identifier="${4:-$task_id}"
+  local view_id
+  local buckets_json
+  local bucket_id
+  local bucket_title
+
+  view_id="$(vikunja_kanban_view_for_project "$project_id")"
+  if [ -z "$view_id" ]; then
+    echo "::warning::No kanban view configured for project ${project_id} — skipped bucket move"
+    return 0
+  fi
+
+  buckets_json=$(curl -sS \
+    -H "$(vikunja_auth_header)" \
+    -H "Content-Type: application/json" \
+    "${VIKUNJA_API_URL}/projects/${project_id}/views/${view_id}/buckets") || {
+    echo "::warning::Could not list buckets for project ${project_id} view ${view_id} — skipped bucket move"
+    return 0
+  }
+
+  if ! bucket_id="$(vikunja_find_bucket_id "$buckets_json" "$bucket_kind" "$project_id")"; then
+    echo "::warning::No ${bucket_kind} bucket found for project ${project_id} view ${view_id} — skipped bucket move (add kanban column and set fallback id in vikunja_bucket_fallback_id)"
+    return 0
+  fi
+
+  if curl -sS \
+    -X POST \
+    -H "$(vikunja_auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --argjson task_id "$task_id" '{task_id: $task_id}')" \
+    "${VIKUNJA_API_URL}/projects/${project_id}/views/${view_id}/buckets/${bucket_id}/tasks" >/dev/null; then
+    bucket_title=$(echo "$buckets_json" | jq -r --argjson id "$bucket_id" '
+      if type == "array" then
+        (.[] | select(.id == $id) | .title) // empty
+      else
+        empty
+      end
+    ')
+    echo "Moved ${identifier} to bucket: ${bucket_title:-${bucket_kind}}"
+  else
+    echo "::warning::Failed to move ${identifier} to ${bucket_kind} bucket ${bucket_id}"
+  fi
+}

--- a/scripts/vikunja/start-ticket.sh
+++ b/scripts/vikunja/start-ticket.sh
@@ -15,22 +15,6 @@ fi
 
 vikunja_load_credentials
 
-kanban_view_for_project() {
-  case "$1" in
-    3) echo 12 ;; # HL
-    1) echo 4 ;;  # ME
-    *) echo "" ;;
-  esac
-}
-
-doing_bucket_fallback() {
-  case "$1" in
-    3) echo 8 ;;
-    1) echo 2 ;;
-    *) echo "" ;;
-  esac
-}
-
 TASK_JSON=$(curl -sf \
   -H "$(vikunja_auth_header)" \
   -H "Content-Type: application/json" \
@@ -60,57 +44,4 @@ else
   echo "start_date already set on ${IDENTIFIER:-$TASK_ID} — leaving unchanged"
 fi
 
-VIEW_ID="$(kanban_view_for_project "$PROJECT_ID")"
-if [ -z "$VIEW_ID" ]; then
-  echo "::warning::No kanban view configured for project ${PROJECT_ID} — skipped bucket move"
-  exit 0
-fi
-
-BUCKETS_JSON=$(curl -sS \
-  -H "$(vikunja_auth_header)" \
-  -H "Content-Type: application/json" \
-  "${VIKUNJA_API_URL}/projects/${PROJECT_ID}/views/${VIEW_ID}/buckets") || {
-  echo "::warning::Could not list buckets for project ${PROJECT_ID} view ${VIEW_ID} — skipped bucket move"
-  exit 0
-}
-
-DOING_BUCKET_ID=$(echo "$BUCKETS_JSON" | jq -r '
-  if type == "object" and .message then empty else
-    [.[] | select(
-      (.title | ascii_downcase) == "doing"
-      or (.title | ascii_downcase) == "in progress"
-      or (.title | ascii_downcase | test("in[ -]?progress"))
-      or (.title | ascii_downcase | test("^doing"))
-    )] | first | .id // empty
-  end
-')
-
-if [ -z "$DOING_BUCKET_ID" ] || [ "$DOING_BUCKET_ID" = "null" ]; then
-  DOING_BUCKET_ID="$(doing_bucket_fallback "$PROJECT_ID")"
-  if [ -n "$DOING_BUCKET_ID" ]; then
-    echo "Using fallback Doing bucket id ${DOING_BUCKET_ID} for project ${PROJECT_ID}"
-  fi
-fi
-
-if [ -z "$DOING_BUCKET_ID" ] || [ "$DOING_BUCKET_ID" = "null" ]; then
-  echo "::warning::No Doing/In Progress bucket found for project ${PROJECT_ID} view ${VIEW_ID} — skipped bucket move"
-  exit 0
-fi
-
-if curl -sS \
-  -X POST \
-  -H "$(vikunja_auth_header)" \
-  -H "Content-Type: application/json" \
-  -d "$(jq -n --argjson task_id "$TASK_ID" '{task_id: $task_id}')" \
-  "${VIKUNJA_API_URL}/projects/${PROJECT_ID}/views/${VIEW_ID}/buckets/${DOING_BUCKET_ID}/tasks" >/dev/null; then
-  BUCKET_TITLE=$(echo "$BUCKETS_JSON" | jq -r --argjson id "$DOING_BUCKET_ID" '
-    if type == "array" then
-      (.[] | select(.id == $id) | .title) // "Doing"
-    else
-      "Doing"
-    end
-  ')
-  echo "Moved ${IDENTIFIER:-$TASK_ID} to bucket: ${BUCKET_TITLE}"
-else
-  echo "::warning::Failed to move ${IDENTIFIER:-$TASK_ID} to Doing bucket ${DOING_BUCKET_ID}"
-fi
+vikunja_move_task_to_bucket "$TASK_ID" "$PROJECT_ID" "doing" "${IDENTIFIER:-$TASK_ID}"


### PR DESCRIPTION
## Summary
- Refactor kanban bucket moves into shared `lib.sh` helpers
- `finish-work.sh` moves tickets to **For Review** when a PR is opened
- `start-ticket.sh` uses the same helpers for **Doing** bucket moves
- HL fallback bucket ids: Doing **8**, For Review **13** (buckets list API unavailable with service token)

**Vikunja:** [HL-9](https://vikunja.christerrile.com/tasks/9) — Improve Vikunja workflow scripts for PR review status

## Test plan
- [ ] `scripts/vikunja/start-ticket.sh {id}` moves HL ticket to Doing
- [ ] `scripts/vikunja/finish-work.sh {id} {pr_url}` moves HL ticket to For Review and comments with PR link
- [ ] Merge closes ticket via tooling-only path (scripts-only change)

Made with [Cursor](https://cursor.com)