### PR TITLE
[HL-12] Fix Vikunja auto-close task lookup

### DIFF
--- a/scripts/vikunja/close-ticket.sh
+++ b/scripts/vikunja/close-ticket.sh
@@ -15,53 +15,6 @@ CLOSE_REASON="${CLOSE_REASON:-deploy}"
 
 vikunja_load_credentials
 
-project_id_for_prefix() {
-  case "$1" in
-    HL) echo 3 ;;
-    ME) echo 1 ;;
-    *) echo "" ;;
-  esac
-}
-
-lookup_task_id() {
-  local identifier="$1"
-  local expected_project="$2"
-  local task_num="${identifier##*-}"
-  local response
-  local actual_identifier
-  local actual_project
-  local done
-
-  response=$(curl -sf \
-    -H "$(vikunja_auth_header)" \
-    -H "Content-Type: application/json" \
-    "${VIKUNJA_API_URL}/tasks/${task_num}" 2>/dev/null) || {
-    echo "::warning::Could not fetch Vikunja task ${task_num} for ${identifier}"
-    return 1
-  }
-
-  actual_identifier=$(echo "$response" | jq -r '.identifier // empty')
-  actual_project=$(echo "$response" | jq -r '.project_id // empty')
-  done=$(echo "$response" | jq -r '.done // false')
-
-  if [ "$actual_identifier" != "$identifier" ]; then
-    echo "::warning::Task ${task_num} identifier mismatch: expected ${identifier}, got ${actual_identifier}"
-    return 1
-  fi
-
-  if [ "$actual_project" != "$expected_project" ]; then
-    echo "::warning::Task ${identifier} project mismatch: expected ${expected_project}, got ${actual_project}"
-    return 1
-  fi
-
-  if [ "$done" = "true" ]; then
-    echo "Task ${identifier} is already done — skipping"
-    return 2
-  fi
-
-  echo "$task_num"
-}
-
 mark_task_done() {
   local task_id="$1"
   local task_json
@@ -98,15 +51,17 @@ fi
 [ -n "$GITHUB_RUN_URL" ] && COMMENT+=$'\n\n'"Workflow: ${GITHUB_RUN_URL}"
 
 for identifier in "${IDENTIFIERS[@]}"; do
-  prefix="${identifier%%-*}"
-  project_id="$(project_id_for_prefix "$prefix")"
-
-  if [ -z "$project_id" ]; then
-    echo "::warning::Unknown ticket prefix in ${identifier} — skipping"
+  if ! task_id="$(vikunja_lookup_task_id "$identifier")"; then
+    echo "::warning::Could not resolve Vikunja task for ${identifier} — skipping"
     continue
   fi
 
-  if ! task_id="$(lookup_task_id "$identifier" "$project_id")"; then
+  task_json=$(curl -sf \
+    -H "$(vikunja_auth_header)" \
+    -H "Content-Type: application/json" \
+    "${VIKUNJA_API_URL}/tasks/${task_id}")
+  if [ "$(echo "$task_json" | jq -r '.done // false')" = "true" ]; then
+    echo "Task ${identifier} is already done — skipping"
     continue
   fi
 


### PR DESCRIPTION
## Summary
- `close-ticket.sh` now uses `vikunja_lookup_task_id` from `lib.sh` (same as `log-usage.sh`)
- Fixes silent skip when Vikunja task id ≠ HL number (e.g. HL-11 is task id 12, not 11)

**Vikunja:** [HL-12](https://vikunja.christerrile.com/tasks/13) — Fix Vikunja auto-close task lookup by identifier

**Root cause:** HL-11 merge ran Close Vikunja successfully but looked up `/tasks/11` → HL-10 → identifier mismatch → skip.

## Test plan
- [ ] Merge and confirm HL-12 auto-closes
- [ ] Future HL-N tickets close correctly even when task id diverges from N

Made with [Cursor](https://cursor.com)