### PR TITLE
[HL-15] Validate secrets before stack deploy

### DIFF
--- a/ansible/roles/docker_stack/tasks/main.yml
+++ b/ansible/roles/docker_stack/tasks/main.yml
@@ -30,6 +30,18 @@
   register: docker_stack_sync_result
   changed_when: docker_stack_sync_result.stdout | length > 0
 
+- name: Validate required secrets — {{ docker_stack_name }}
+  ansible.builtin.assert:
+    that:
+      - lookup('env', item) | length > 0
+    fail_msg: >-
+      Required secret '{{ item }}' is missing or empty for stack '{{ docker_stack_name }}'.
+      Add it to Infisical prod before deploying.
+  loop: "{{ stack_infra.secrets | default([]) }}"
+  when:
+    - stack_infra.env_file | default(false)
+    - stack_infra.secrets | default([]) | length > 0
+
 - name: Render .env from secrets — {{ docker_stack_name }}
   ansible.builtin.template:
     src: env.j2


### PR DESCRIPTION
## Summary
- Add Ansible pre-deploy check: fail fast when any `infra.yml` secret is missing or empty
- Prevents cryptic `docker compose` errors like `invalid spec: :/downloads` when env vars are unset

**Vikunja:** [HL-15](https://vikunja.christerrile.com/tasks/16) — Fix media-service deploy — empty TRANSMISSION_DOWNLOAD_PATH

Follow-up to [HL-2](https://vikunja.christerrile.com/tasks/2) deploy failure on artemis (#42).

## Root cause
`TRANSMISSION_DOWNLOAD_PATH` was not set in Infisical prod after the HL-2 rename from `DOWNLOAD_PATH`.

## Test plan
- [ ] Add `TRANSMISSION_DOWNLOAD_PATH` to Infisical prod
- [ ] Merge this PR
- [ ] Redeploy `media-service` — should succeed
- [ ] Verify missing secret on another stack produces clear Ansible assert message (optional)


Made with [Cursor](https://cursor.com)