### PR TITLE
[HL-15] Retrigger media-service deploy

### DIFF
--- a/stacks/media-service/docker-compose.yml
+++ b/stacks/media-service/docker-compose.yml
@@ -1,3 +1,5 @@
+name: media-service
+
 services:
   plex:
     image: plexinc/pms-docker


### PR DESCRIPTION
## Summary
- Set explicit compose project name `media-service` to retrigger stack deploy after Infisical secret fix

**Vikunja:** [HL-15](https://vikunja.christerrile.com/tasks/16) — Fix media-service deploy — empty TRANSMISSION_DOWNLOAD_PATH

## Test plan
- [ ] Merge and confirm `media-service` deploy succeeds on artemis
- [ ] Transmission, Radarr, Sonarr mount downloads path correctly


Made with [Cursor](https://cursor.com)