### PR TITLE
[HL-16] Fix Doplarr LOG_LEVEL config

### DIFF
--- a/stacks/media-service/docker-compose.yml
+++ b/stacks/media-service/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       SONARR__API: ${SONARR_TOKEN}
       SONARR__URL: http://sonarr:8989
       DISCORD__MAX_RESULTS: 20
-      LOG_LEVEL: info
+      LOG_LEVEL: ":info"
     volumes:
       - doplarr_config:/config
 


### PR DESCRIPTION
## Summary
- Change Doplarr `LOG_LEVEL` from `info` to `:info` (Clojure keyword format)
- Fixes config validation fatal on container start

**Vikunja:** [HL-16](https://vikunja.christerrile.com/tasks/17) — Fix Doplarr LOG_LEVEL config in media-service

## Test plan
- [ ] Merge and redeploy `media-service`
- [ ] Doplarr container starts without config spec errors
- [ ] Bot responds in Discord


Made with [Cursor](https://cursor.com)