### PR TITLE
[HL-16] Pin Doplarr image to 3.8.0

### DIFF
--- a/stacks/media-service/docker-compose.yml
+++ b/stacks/media-service/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       - pangolin.public-resources.sonarr.targets[0].method=http
 
   doplarr:
-    image: lscr.io/linuxserver/doplarr:latest
+    image: lscr.io/linuxserver/doplarr:3.8.0
     container_name: doplarr
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- Pin `lscr.io/linuxserver/doplarr` to `3.8.0` instead of `:latest`
- Avoids broken upstream build `null-ls141` (2026-06-28) with corrupt/missing `doplarr.jar`

**Vikunja:** [HL-16](https://vikunja.christerrile.com/tasks/17) — Fix Doplarr LOG_LEVEL config in media-service

Follow-up to #45 after container logs showed `Invalid or corrupt jarfile`.

## Test plan
- [ ] Merge and redeploy `media-service`
- [ ] Doplarr starts with valid JAR (no corrupt jarfile errors)
- [ ] Bot responds in Discord


Made with [Cursor](https://cursor.com)