### PR TITLE
[HL-17] Smarter deploy triggers and compose validation fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,6 @@ jobs:
           DAGS_CHANGED=$(git diff --name-only HEAD~1 HEAD -- stacks/dagu/dags/ | head -1 || true)
           DAGU_RUNTIME_CHANGED=$(git diff --name-only HEAD~1 HEAD -- stacks/dagu/ \
             | grep -v '^stacks/dagu/dags/' | head -1 || true)
-          ANSIBLE_CHANGED=$(git diff --name-only HEAD~1 HEAD -- ansible/ | head -1 || true)
 
           if [ -n "$DAGS_CHANGED" ]; then
             echo "should_sync_dags=true" >> "$GITHUB_OUTPUT"
@@ -93,11 +92,7 @@ jobs:
             echo "should_bootstrap_dagu=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ -n "$ANSIBLE_CHANGED" ]; then
-            echo "deploy_stacks=all" >> "$GITHUB_OUTPUT"
-            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
-            echo "should_close_without_deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -n "$DEPLOY_STACKS" ]; then
+          if [ -n "$DEPLOY_STACKS" ]; then
             echo "deploy_stacks=$DEPLOY_STACKS" >> "$GITHUB_OUTPUT"
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             echo "should_close_without_deploy=false" >> "$GITHUB_OUTPUT"
@@ -105,8 +100,8 @@ jobs:
             echo "deploy_stacks=" >> "$GITHUB_OUTPUT"
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
 
-            NON_TOOLING=$(echo "$ALL_CHANGED" | grep -vE '^(\.github/|scripts/)' | head -1 || true)
-            if [ -n "$ALL_CHANGED" ] && [ -z "$NON_TOOLING" ] \
+            NON_DEPLOY=$(echo "$ALL_CHANGED" | grep -vE '^(\.github/|scripts/|ansible/)' | head -1 || true)
+            if [ -n "$ALL_CHANGED" ] && [ -z "$NON_DEPLOY" ] \
               && echo "${{ github.event.head_commit.message }}" | grep -qE '(HL|ME)-[0-9]+'; then
               echo "should_close_without_deploy=true" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,8 +25,16 @@ jobs:
 
             # Collect env var references and set dummy values so
             # docker compose config can parse the file structure.
+            # Bind-mount sources must be absolute paths — "placeholder"
+            # is parsed as a named volume and fails validation.
             dummy_env=$(grep -oP '\$\{?\K[A-Z_]+' "$f" | sort -u \
-              | while read -r var; do echo "$var=placeholder"; done)
+              | while read -r var; do
+                  if grep -q "\${${var}}:" "$f"; then
+                    echo "${var}=/tmp/ci-placeholder"
+                  else
+                    echo "${var}=placeholder"
+                  fi
+                done)
 
             if env $dummy_env docker compose -f "$f" config --quiet 2>&1; then
               echo "  ✓ $f"
@@ -42,7 +50,13 @@ jobs:
         if: hashFiles('gateway/docker-compose.yml') != ''
         run: |
           dummy_env=$(grep -oP '\$\{?\K[A-Z_]+' gateway/docker-compose.yml \
-            | sort -u | while read -r var; do echo "$var=placeholder"; done)
+            | sort -u | while read -r var; do
+                if grep -q "\${${var}}:" gateway/docker-compose.yml; then
+                  echo "${var}=/tmp/ci-placeholder"
+                else
+                  echo "${var}=placeholder"
+                fi
+              done)
           env $dummy_env docker compose -f gateway/docker-compose.yml config --quiet
 
       - name: Validate infra.yml schemas


### PR DESCRIPTION
## Summary
- Stop redeploying all stacks when only `ansible/**` changes; deploy only stacks with files changed under `stacks/<name>/`
- Treat ansible-only merges like tooling merges for Vikunja auto-close when the commit message includes a ticket id
- Fix compose validation for bind-mount env vars (e.g. `TRANSMISSION_DOWNLOAD_PATH` in media-service)

**Vikunja:** [HL-17](https://vikunja.christerrile.com/tasks/18) — Smarter stack deploys: change-scoped triggers and selective restarts

## Test plan
- [ ] Open PR — Validate workflow passes (media-service compose no longer fails)
- [ ] Merge ansible-only change — deploy workflow skips stack deploy; Vikunja ticket closes without deploy
- [ ] Merge stack-only change — only affected stack(s) deploy
- [ ] Manual `workflow_dispatch` with explicit stack list still works


Made with [Cursor](https://cursor.com)