### PR TITLE
[HL-18] Migrate Portainer stack to icarus

### DIFF
--- a/central-host/docker-compose.yml
+++ b/central-host/docker-compose.yml
@@ -33,38 +33,6 @@ services:
       - "traefik.http.routers.traefik-secure.tls.certresolver=dns"
       - "traefik.http.routers.traefik-secure.service=api@internal"
 
-  portainer:
-    image: portainer/portainer-ee:latest
-    container_name: portainer
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    networks:
-      - traefik-proxy
-    ports:
-      - 8000:8000
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - portainer_data:/data
-    labels:
-      - "traefik.enable=true"
-    #  - "traefik.http.routers.portainer.entrypoints=http"
-    #  - "traefik.http.routers.portainer.rule=Host(`services.${DOMAIN}`)"
-      - "traefik.http.middlewares.portainer-https-redirect.redirectscheme.scheme=https"
-      - "traefik.http.routers.portainer.middlewares=portainer-https-redirect"
-      - "traefik.http.routers.portainer-secure.entrypoints=https"
-      - "traefik.http.routers.portainer-secure.rule=Host(`services.${DOMAIN}`)"
-      - "traefik.http.routers.portainer-secure.tls=true"
-      - "traefik.http.routers.portainer-secure.tls.certresolver=dns"
-      - "traefik.http.routers.portainer-secure.service=portainer"
-      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
-      - "traefik.docker.network=traefik-proxy"
-
-
 networks:
   traefik-proxy:
     external: true
-
-volumes:
-  portainer_data:

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  portainer:
+    image: portainer/portainer-ee:latest
+    container_name: portainer
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - pangolin
+    ports:
+      - 8000:8000
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - portainer_data:/data
+    labels:
+      # Pangolin blueprint (public resource) — see https://docs.pangolin.net/manage/blueprints
+      - pangolin.public-resources.portainer.name=portainer
+      - pangolin.public-resources.portainer.full-domain=services.${DOMAIN}
+      - pangolin.public-resources.portainer.protocol=http
+      - pangolin.public-resources.portainer.targets[0].hostname=portainer
+      - pangolin.public-resources.portainer.targets[0].port=9000
+      - pangolin.public-resources.portainer.targets[0].path=/
+      - pangolin.public-resources.portainer.targets[0].method=http
+
+networks:
+  pangolin:
+    external: true
+
+volumes:
+  portainer_data:
+    external: true

--- a/stacks/portainer/infra.yml
+++ b/stacks/portainer/infra.yml
@@ -1,0 +1,9 @@
+host: icarus
+deploy_path: /home/deploy/dockerlab/stacks/portainer
+env_file: true
+secrets:
+  - DOMAIN
+docker_volumes:
+  portainer_data:
+    backup: true
+depends_on_stacks: []


### PR DESCRIPTION
## Summary
- Add `stacks/portainer/` with Pangolin labels for `services.${DOMAIN}` on icarus
- Remove Portainer from legacy `central-host/docker-compose.yml` (Traefik unchanged)
- Uses external `portainer_data` volume for migrated data

**Vikunja:** [HL-18](https://vikunja.christerrile.com/tasks/19) — Migrate Portainer stack from central-host into stacks/

## Test plan
- [ ] Copy Portainer data into `portainer_data` volume on icarus before deploy
- [ ] Deploy `portainer` stack via Dagu/Ansible pipeline
- [ ] Verify Portainer reachable at `https://services.${DOMAIN}`
- [ ] Confirm Glance Portainer widget still works
- [ ] Stop legacy Portainer on artemis after cutover


Made with [Cursor](https://cursor.com)