### PR TITLE
[HL-18] Use separate webhook token for push-tools DAG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -445,11 +445,11 @@ jobs:
         id: trigger
         env:
           DAGU_BASE_URL: ${{ secrets.DAGU_WEBHOOK_URL }}
-          DAGU_WEBHOOK_TOKEN: ${{ secrets.DAGU_WEBHOOK_TOKEN }}
+          DAGU_PUSH_TOOLS_WEBHOOK_TOKEN: ${{ secrets.DAGU_PUSH_TOOLS_WEBHOOK_TOKEN }}
         run: |
           HTTP_STATUS=$(curl -s -o /tmp/dagu-response.json -w "%{http_code}" \
             -X POST "${DAGU_BASE_URL}/api/v1/webhooks/push-tools" \
-            -H "Authorization: Bearer ${DAGU_WEBHOOK_TOKEN}" \
+            -H "Authorization: Bearer ${DAGU_PUSH_TOOLS_WEBHOOK_TOKEN}" \
             -H "Content-Type: application/json" \
             -d '{
               "payload": {


### PR DESCRIPTION
## Summary
- Use `DAGU_PUSH_TOOLS_WEBHOOK_TOKEN` for the push-tools CI webhook trigger
- Keeps `DAGU_WEBHOOK_TOKEN` for deploy-stacks only (Dagu issues one token per DAG webhook)

**Vikunja:** [HL-18](https://vikunja.christerrile.com/tasks/19) — Migrate Portainer stack from central-host into stacks/

## Setup required before merge
1. Create webhook for `push-tools` in Dagu UI (or `POST /api/v1/dags/push-tools/webhook`)
2. Add GitHub Actions secret `DAGU_PUSH_TOOLS_WEBHOOK_TOKEN` with the returned `dagu_wh_...` token

## Test plan
- [ ] `DAGU_PUSH_TOOLS_WEBHOOK_TOKEN` secret added to GitHub
- [ ] Push changing `site/` or `scripts/` triggers push-tools without 401
- [ ] deploy-stacks webhook still uses `DAGU_WEBHOOK_TOKEN` unchanged


Made with [Cursor](https://cursor.com)