### PR TITLE
[HL-18] Fix push-tools DAG script path before repo clone

### DIFF
--- a/stacks/dagu/dags/push-tools.yaml
+++ b/stacks/dagu/dags/push-tools.yaml
@@ -16,8 +16,6 @@ params:
 steps:
   - name: Resolve hosts
     command: |
-      source scripts/resolve-site-hosts.sh
-
       if [ -n "${HOSTS}" ]; then
         echo "${HOSTS}"
       elif [ -n "${WEBHOOK_PAYLOAD}" ]; then
@@ -61,6 +59,7 @@ steps:
         exit 1
       fi
 
+      cd /workspace/dockerlab
       source scripts/resolve-site-hosts.sh
 
       if [ "${RESOLVED_HOSTS}" = "all" ]; then


### PR DESCRIPTION
## Summary
- Remove unnecessary `source scripts/resolve-site-hosts.sh` from the **Resolve hosts** step (runs before git clone)
- **Build host list** now `cd /workspace/dockerlab` before sourcing the script (after clone)

Fixes: `scripts/resolve-site-hosts.sh: No such file or directory`

**Vikunja:** [HL-18](https://vikunja.christerrile.com/tasks/19)

## Test plan
- [ ] Merge and let Dagu git-sync pick up updated DAG
- [ ] Trigger push-tools manually or via CI — Resolve hosts and Build host list steps succeed


Made with [Cursor](https://cursor.com)