### PR TITLE
[HL-19] Register gaia host and add deploy-gateway DAG

### DIFF
--- a/ansible/inventory/host_vars/gaia.yml
+++ b/ansible/inventory/host_vars/gaia.yml
@@ -1,0 +1,2 @@
+---
+ansible_host: "{{ lookup('env', 'GAIA_ANSIBLE_HOST') }}"

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -8,12 +8,11 @@ all:
           ansible_ssh_private_key_file: /home/dagu/.ssh/id_ed25519
     vps:
       hosts:
+        gaia:
+          # ansible_host from GAIA_ANSIBLE_HOST (Infisical prod) — see host_vars/gaia.yml
+          ansible_user: deploy
+          ansible_ssh_private_key_file: /home/dagu/.ssh/id_ed25519
         icarus:
           # ansible_host from ICARUS_ANSIBLE_HOST (Infisical prod) — see host_vars/icarus.yml
           ansible_user: deploy
           ansible_ssh_private_key_file: /home/dagu/.ssh/id_ed25519
-        # Add future VPS hosts here:
-        # zeus:
-        #   ansible_host: x.x.x.x
-        #   ansible_user: deploy
-        #   ansible_ssh_private_key_file: /home/dagu/.ssh/id_ed25519

--- a/ansible/playbooks/deploy-gateway.yml
+++ b/ansible/playbooks/deploy-gateway.yml
@@ -8,7 +8,7 @@
 # Required env vars: DOMAIN, PANGOLIN_SECRET, LETSENCRYPT_EMAIL
 
 - name: Deploy Pangolin gateway
-  hosts: "{{ gateway_target_host | default('hermes') }}"
+  hosts: "{{ gateway_target_host | default('gaia') }}"
   become: true
   vars:
     gateway_deploy_path: /opt/gateway

--- a/site/hosts.yml
+++ b/site/hosts.yml
@@ -25,3 +25,14 @@ hosts:
       - NEWT_SECRET
       - PORTAINER_EDGE_ID
       - PORTAINER_EDGE_KEY
+
+  gaia:
+    scripts_path: /home/deploy/dockerlab/scripts
+    site_path: /home/deploy/dockerlab/site
+    infisical_path: /sites/gaia
+    secrets:
+      - PANGOLIN_ENDPOINT
+      - NEWT_ID
+      - NEWT_SECRET
+      - PORTAINER_EDGE_ID
+      - PORTAINER_EDGE_KEY

--- a/stacks/dagu/dags/deploy-gateway.yaml
+++ b/stacks/dagu/dags/deploy-gateway.yaml
@@ -1,0 +1,88 @@
+description: Deploy Pangolin gateway via Ansible (Git Sync managed)
+
+env:
+  - INFISICAL_PROJECT_ID: ${INFISICAL_PROJECT_ID}
+  - REPO_URL: ${REPO_URL}
+  - INFISICAL_URL: ${INFISICAL_API_URL}
+
+secrets:
+  - name: INFISICAL_TOKEN
+    provider: env
+    key: INFISICAL_TOKEN
+
+params:
+  - HOST: "gaia"
+
+steps:
+  - name: Resolve target host
+    command: |
+      if [ -n "${HOST}" ]; then
+        echo "${HOST}"
+      else
+        echo "gaia"
+      fi
+    output: TARGET_HOST
+
+  - name: Setup SSH
+    command: |
+      set -e
+      export INFISICAL_DISABLE_UPDATE_CHECK=true
+
+      infisical secrets get DEPLOY_SSH_KEY \
+        --domain "$INFISICAL_URL" \
+        --token "$INFISICAL_TOKEN" \
+        --projectId "$INFISICAL_PROJECT_ID" \
+        --env prod \
+        --expand=false \
+        --plain --silent \
+      | write-ssh-key.py
+
+      ssh-keyscan -t ed25519 github.com >> /home/dagu/.ssh/known_hosts 2>/dev/null
+      echo "SSH key validated and known_hosts configured"
+
+  - name: Clone repo
+    command: |
+      if [ -z "${REPO_URL}" ]; then
+        echo "ERROR: REPO_URL env var is not set" >&2
+        exit 1
+      fi
+      rm -rf /workspace/dockerlab
+      git clone --depth 1 --branch main "${REPO_URL}" /workspace/dockerlab
+
+  - name: Run Ansible gateway deploy
+    working_dir: /workspace/dockerlab
+    command: |
+      if [ -z "${INFISICAL_URL}" ]; then
+        echo "ERROR: INFISICAL_URL is not set" >&2
+        exit 1
+      fi
+
+      if [ -z "${TARGET_HOST}" ]; then
+        echo "ERROR: TARGET_HOST is empty" >&2
+        exit 1
+      fi
+
+      cd ansible
+
+      /opt/ansible/bin/ansible-galaxy collection install \
+        -r requirements.yml \
+        -p /opt/ansible/collections
+
+      infisical run \
+        --domain "$INFISICAL_URL" \
+        --token "$INFISICAL_TOKEN" \
+        --projectId "$INFISICAL_PROJECT_ID" \
+        --env prod \
+        -- \
+        /opt/ansible/bin/ansible-playbook playbooks/deploy-gateway.yml \
+          -e ansible_ssh_private_key_file=/home/dagu/.ssh/id_ed25519 \
+          -e "gateway_target_host=${TARGET_HOST}" \
+          --limit "${TARGET_HOST}"
+    env:
+      - ANSIBLE_FORCE_COLOR: "true"
+
+handler_on:
+  failure:
+    command: echo "[FAILED] Gateway deploy — host=${TARGET_HOST}"
+  success:
+    command: echo "[OK] Deployed gateway to host=${TARGET_HOST}"


### PR DESCRIPTION
## Summary
- Register **gaia** in Ansible inventory (`GAIA_ANSIBLE_HOST` via Infisical) and `site/hosts.yml` for push-tools
- Point `deploy-gateway.yml` default target at `gaia` (replacing legacy `hermes`)
- Add `deploy-gateway` Dagu DAG for manual gateway deploys (SSH setup → clone → `infisical run` → Ansible)

**Vikunja:** [HL-19](https://vikunja.christerrile.com/tasks/20) — Register gaia host for gateway and site tools

## Manual steps after merge
- [ ] Set `GAIA_ANSIBLE_HOST` in Infisical prod
- [ ] Sync Dagu DAGs (`deploy-gateway` appears after Git Sync pull)
- [ ] Trigger `deploy-gateway` manually from Dagu UI to validate
- [ ] Optionally add `/sites/gaia/` secrets and run push-tools for edge agent

## Test plan
- [ ] Dagu Git Sync picks up `stacks/dagu/dags/deploy-gateway.yaml`
- [ ] Manual `deploy-gateway` run succeeds against gaia
- [ ] `push-tools` with `HOSTS=gaia` resolves host after Infisical secret is set


Made with [Cursor](https://cursor.com)