### PR TITLE
[HL-20] Add explicit names to Dagu parallel steps

### DIFF
--- a/stacks/dagu/dags/deploy-stacks.yaml
+++ b/stacks/dagu/dags/deploy-stacks.yaml
@@ -65,7 +65,8 @@ steps:
         | awk 'NF' | jq -R . | jq -s .
     output: STACK_LIST
 
-  - call: deploy-stack
+  - name: Deploy stacks
+    call: deploy-stack
     parallel:
       items: ${STACK_LIST}
       max_concurrent: 1

--- a/stacks/dagu/dags/push-tools.yaml
+++ b/stacks/dagu/dags/push-tools.yaml
@@ -70,7 +70,8 @@ steps:
         | awk 'NF' | jq -R . | jq -s .
     output: HOST_LIST
 
-  - call: push-tools-host
+  - name: Push to hosts
+    call: push-tools-host
     parallel:
       items: ${HOST_LIST}
       max_concurrent: 1


### PR DESCRIPTION
## Summary
- Add `name: Push to hosts` on the parallel `push-tools-host` step in `push-tools.yaml`
- Add `name: Deploy stacks` on the parallel `deploy-stack` step in `deploy-stacks.yaml`
- Improves Dagu graph and step table labels (e.g. `Push to hosts -> push-tools-host x3` instead of `parallel_N`)

**Vikunja:** [HL-20](https://vikunja.christerrile.com/tasks/21) — Add explicit names to Dagu parallel steps

## Test plan
- [ ] Merge triggers Dagu Git Sync pull for `stacks/dagu/dags/**`
- [ ] Open a `push-tools` run in Dagu UI — parallel step shows `Push to hosts`
- [ ] Open a `deploy-stacks` run — parallel step shows `Deploy stacks`

Made with [Cursor](https://cursor.com)